### PR TITLE
Add type None to recipe_name and bean_name + do not Raise on error, just ignore

### DIFF
--- a/mahlkoenig/__init__.py
+++ b/mahlkoenig/__init__.py
@@ -248,9 +248,11 @@ class Grinder:
             try:
                 raw: Dict[str, Any] = msg.json()
                 parsed = parse(raw)
-            except (json.JSONDecodeError, MahlkoenigProtocolError):
-                _LOGGER.warning(f"Ignoring malformed frame: {msg.data}")
-                raise MahlkoenigProtocolError("Malformed frame", data=msg)
+            except json.JSONDecodeError:
+                _LOGGER.warning(f"Invalid JSON received: {msg.data}")
+                continue  # JSON invalide = ignorer
+            except MahlkoenigProtocolError:
+                _LOGGER.error(f"Malformed frame: {msg.data}")
                 continue
             except Exception:
                 _LOGGER.exception("Unexpected error while parsing frame", exc_info=True)

--- a/mahlkoenig/models.py
+++ b/mahlkoenig/models.py
@@ -146,8 +146,8 @@ class WifiInfo(NetworkModel):
 class Recipe(BaseModel):
     recipe_no: NonNegativeInt
     grind_time: timedelta
-    name: str
-    bean_name: str
+    name: str | None
+    bean_name: str | None
     grinding_degree: NonNegativeInt
     brewing_type: BrewType
     guid: str

--- a/tests/test_websocket_models.py
+++ b/tests/test_websocket_models.py
@@ -135,6 +135,39 @@ def test_parse_recipe_message():
     assert message.recipe.last_modify_time == expected_time
 
 
+def test_parse_recipe_with_empty_names_message():
+    data = {
+        "MsgId": 193396738,
+        "SessionId": 1192944753,
+        "Recipe": {
+            "RecipeNo": 2,
+            "GrindTime": 115,
+            "Name": "",
+            "BeanName": "",
+            "GrindingDegree": 50,
+            "BrewingType": 2,
+            "Guid": "e408f736-0086-4e74-a28c-048ce0465203",
+            "LastModifyIndex": 9,
+            "LastModifyTime": 1728658413,
+        },
+    }
+
+    message = parse(data)
+    assert message.msg_id == 193396738
+    assert message.session_id == 1192944753
+    assert message.recipe.recipe_no == 2
+    assert message.recipe.grind_time.total_seconds() == 11.5
+    assert message.recipe.name == ""
+    assert message.recipe.bean_name == ""
+    assert message.recipe.grinding_degree == 50
+    assert message.recipe.brewing_type == BrewType.DOUBLE_SHOT
+    assert message.recipe.guid == "e408f736-0086-4e74-a28c-048ce0465203"
+    assert message.recipe.last_modify_index == 9
+
+    expected_time = datetime.utcfromtimestamp(1728658413).replace(tzinfo=timezone.utc)
+    assert message.recipe.last_modify_time == expected_time
+
+
 def test_parse_response_status_message_success():
     data = {
         "MsgId": 8,


### PR DESCRIPTION
After getting the following error in home assistant, I realized that Name and BeanName can be None

```
mahlkoenig.exceptions.MahlkoenigProtocolError: Malformed frame (received: WSMessage(type=<WSMsgType.TEXT: 1>, data='{"Recipe":{"RecipeNo":1,"GrindTime":61,"Name":"","BeanName":"","GrindingDegree":0,"BrewingType":0,"Guid":"","LastModifyIndex":0,"LastModifyTime":0},"MsgId":9568256,"SessionId":93026578}', extra=''))
```


